### PR TITLE
Fix the heading Markdown in ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-#GameMenu 
+# GameMenu 
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5d324ea6258443a99146a2af7cc38aca)](https://www.codacy.com/app/ParadoxZero/GameMenu-cpp?utm_source=github.com&utm_medium=referral&utm_content=ParadoxZero/GameMenu-cpp&utm_campaign=badger)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)   ![Language (C++)](https://img.shields.io/badge/powered_by-C++-brightgreen.svg?style=flat-square)   [![Build Status](https://travis-ci.org/ParadoxZero/GameMenu-cpp.svg?branch=master)](https://travis-ci.org/ParadoxZero/GameMenu-cpp)  
@@ -6,12 +6,12 @@
  
 This is a C++ library to help create Menu UI for games based of sfml. It provides simple and direct pathways to create Menu, add action to it etc.
 
-##How to use?
+## How to use?
 The main purpose of the library is to make creation of menu's in games easy. This achieves it by dividing the Menu into two parts:
   * UI - Options to display
   * Function - The action to perform
  
-####To use the library
+#### To use the library
   
   * First Need to decide the menu items, ie the options available (eg Start, Exit, Highscore etc)
   * Create A vector of `gmenu::MenuItem`. Which contains the title of the item and Action it will perform.
@@ -61,18 +61,18 @@ The main purpose of the library is to make creation of menu's in games easy. Thi
 * Vola, your menu is ready to be used.
      
 
-##[Screenshots!](Screenshots.md)
+## [Screenshots!](Screenshots.md)
 
-##Dependencies
+## Dependencies
   * [Simple and Fast Multimedia Library](http://www.sfml-dev.org/index.php)
   
-    * ####How to install on linux
+    * #### How to install on linux
       
       ```
         $ sudo apt-get install libsfml-dev
       ```
       
-    * ####How to install in Windows (visual studio)
+    * #### How to install in Windows (visual studio)
     
       * Download the binaries from [sfml](http://www.sfml-dev.org/download.php)
       * Open project settings
@@ -81,9 +81,9 @@ The main purpose of the library is to make creation of menu's in games easy. Thi
       * In linker additional external libraries
       * Add `<path to sfml>/lib`
       
-##Installing
+## Installing
 
-####Linux
+#### Linux
   
 * Clone/Download source
 * Go to Project dir
@@ -110,7 +110,7 @@ The main purpose of the library is to make creation of menu's in games easy. Thi
       $ g++ your_output.o -L./lib -lGameMenu -o your_executable
     ```
  
-####Windows (Visual Studio)
+#### Windows (Visual Studio)
  
  * Clone/Download the GameMenu
  * Build for the required platform
@@ -120,10 +120,10 @@ The main purpose of the library is to make creation of menu's in games easy. Thi
  * Build and enjoy.
  
  
- ##Contributions
+ ## Contributions
  If you are looking to contribute, then feel free to create a pull request.
  
- ####Future Possibilities
+ #### Future Possibilities
   * Mouse integration
   * Menu style system. Abiity to alter the menu apearance as per need.
     (Create a style object with nessary specifications, which will be passed to the Menu)


### PR DESCRIPTION
It appears a recent change to Github's Markdown formatting breaks headings that don't have a space between the heading name and it's prefixed hashtags. This makes the headings not display correctly and hard to read. This PR simply inserts a space between all heading hashtags and their names in ReadMe.md, making them display correctly.