### PR TITLE
CMakeLists.txt fix for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD 20)
 if (NOT DEFINED LINK_TYPE)
     message("Library link type not specified, using default - STATIC")
     set(LINK_TYPE STATIC)
+    option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 endif()
 
 include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,10 @@ FetchContent_Declare(SFML
 
 FetchContent_MakeAvailable(SFML)
 
-
-set(SOURCES 
+set(SOURCES
     "public/game_menu/game_menu.h"
     "src/game_menu_impl.cpp"
+    "src/game_menu_impl.h"
 )
 
 add_library(gamemenu ${LINK_TYPE} ${SOURCES})
@@ -51,9 +51,9 @@ set_target_properties(gamemenu PROPERTIES
 
 if(WIN32)
     add_custom_command(
-        TARGET CMakeSFMLProject
+        TARGET gamemenu
         COMMENT "Copy OpenAL DLL"
-        PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${SFML_SOURCE_DIR}/extlibs/bin/$<IF:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>,x64,x86>/openal32.dll $<TARGET_FILE_DIR:CMakeSFMLProject>
+        PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${SFML_SOURCE_DIR}/extlibs/bin/$<IF:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>,x64,x86>/openal32.dll $<TARGET_FILE_DIR:gamemenu>
         VERBATIM)
 endif()
 


### PR DESCRIPTION
Hello,

This first pull request is just the fix to the CmakeLists.txt file to support windows for compile, and running the example project. 

- Disabled Build Shared Libraries was needed for the example project to run on Windows. SFML was defaulting to shared lib without this and running the executable resulted in an exception when the sfml dll could not be found.
 - Added game_menu_impl.h to the sources list so when CMake is used to generate a visual studio project it is added to the project file. This is just a convenience for Visual Studio users.
 - Updated the Win32 DLL custom command to point to the gamemenu library. This was needed to get the build to run on windows.