### PR TITLE
Added Mouse Integration

### DIFF
--- a/src/game_menu_impl.cpp
+++ b/src/game_menu_impl.cpp
@@ -27,16 +27,14 @@ namespace game_menu {
 void Menu::handleEvent(sf::Event &event) {
   auto max_items = _items.size();
   if (event.type == sf::Event::KeyPressed) {
-    if (event.key.code == sf::Keyboard::Up) {
-      _currently_selected_item =
-          (_currently_selected_item + max_items - 1) % max_items;
-    } else if (event.key.code == sf::Keyboard::Down) {
-      _currently_selected_item = (_currently_selected_item + 1) % max_items;
+    if (event.key.code == sf::Keyboard::Up ||
+        event.key.code == sf::Keyboard::Down) {
+      changeCurrSelectedItem(event.key.code == sf::Keyboard::Up);
     } else if (event.key.code == sf::Keyboard::Return) {
-      _items[_currently_selected_item].data.action(_window);
+      performCurrSelectedItemAction();
     }
   }
-  if (event.type == sf::Event::MouseMoved) {
+  else if (event.type == sf::Event::MouseMoved) {
     sf::Vector2f mousePos(event.mouseMove.x, event.mouseMove.y);
 	for (int i = 0; i < _items.size(); ++i) {
 	  if (_items[i].textObj.getGlobalBounds().contains(mousePos)) {
@@ -44,6 +42,22 @@ void Menu::handleEvent(sf::Event &event) {
 	    break;
 	  }
     }
+  }
+  else if (event.type == sf::Event::MouseButtonPressed) {
+	if (event.mouseButton.button == sf::Mouse::Left) {
+      sf::Vector2f mousePos(event.mouseButton.x, event.mouseButton.y);
+      for (int i = 0; i < _items.size(); ++i) {
+        if (_items[i].textObj.getGlobalBounds().contains(mousePos)) {
+          _items[i].data.action(_window);
+          break;
+        }
+      }
+    }
+  }
+  else if (event.type == sf::Event::MouseWheelScrolled) {
+	if (event.mouseWheelScroll.wheel == sf::Mouse::VerticalWheel) {
+      changeCurrSelectedItem(event.mouseWheelScroll.delta > 0.0);
+	}
   }
 } // handleEvent(...)
 
@@ -150,5 +164,17 @@ void Menu::drawMenu() {
   }
 
 } // drawMenu()
+
+void Menu::changeCurrSelectedItem(const bool moveUp) {
+    const auto maxItems = _items.size();
+    _currently_selected_item = moveUp
+        ? (_currently_selected_item + maxItems - 1) % maxItems
+        : (_currently_selected_item + 1) % maxItems;
+} // changeCurrSelectedItem()
+
+void Menu::performCurrSelectedItemAction()
+{
+    _items[_currently_selected_item].data.action(_window);
+} // performCurrSelectedItemAction()
 
 } // namespace game_menu

--- a/src/game_menu_impl.cpp
+++ b/src/game_menu_impl.cpp
@@ -36,14 +36,23 @@ void Menu::handleEvent(sf::Event &event) {
       _items[_currently_selected_item].data.action(_window);
     }
   }
-}
+  if (event.type == sf::Event::MouseMoved) {
+    sf::Vector2f mousePos(event.mouseMove.x, event.mouseMove.y);
+	for (int i = 0; i < _items.size(); ++i) {
+	  if (_items[i].textObj.getGlobalBounds().contains(mousePos)) {
+	    _currently_selected_item = i;
+	    break;
+	  }
+    }
+  }
+} // handleEvent(...)
 
 void Menu::render() {
   setMenu();
   drawMenu();
-}
+} // render(...)
 
-void Menu::writeText(std::string str, sf::Font *font, unsigned int size,
+sf::Text Menu::writeText(std::string str, sf::Font *font, unsigned int size,
                      float x, float y, const Color color) {
   sf::Color textColor(color);
   sf::Text text;
@@ -61,6 +70,7 @@ void Menu::writeText(std::string str, sf::Font *font, unsigned int size,
   }
   text.setPosition(sf::Vector2f(x, y));
   _window.draw(text);
+  return text;
 } // writeText(...)
 
 void Menu::setMenu() {
@@ -135,7 +145,7 @@ void Menu::drawMenu() {
     } else {
       color = _style.colorScheme.itemColor;
     }
-    writeText(_items[i].data.name, _style.ItemFont, _style.ItemFontSize,
+    _items[i].textObj = writeText(_items[i].data.name, _style.ItemFont, _style.ItemFontSize,
               _items[i].location.x, _items[i].location.y, color);
   }
 

--- a/src/game_menu_impl.h
+++ b/src/game_menu_impl.h
@@ -20,6 +20,7 @@ struct coordinates {
 struct Item {
   MenuItem data;
   coordinates location;
+  sf::Text textObj;
 };
 
 class Menu {
@@ -39,7 +40,7 @@ public:
 private:
   void setMenu();
   void drawMenu();
-  void writeText(std::string str, sf::Font* font, unsigned int size, float x,
+  sf::Text writeText(std::string str, sf::Font* font, unsigned int size, float x,
                  float y, const Color color);
   sf::RenderTarget &_window;
   Style _style;

--- a/src/game_menu_impl.h
+++ b/src/game_menu_impl.h
@@ -42,6 +42,8 @@ private:
   void drawMenu();
   sf::Text writeText(std::string str, sf::Font* font, unsigned int size, float x,
                  float y, const Color color);
+  void changeCurrSelectedItem(const bool moveUp);
+  void performCurrSelectedItemAction();
   sf::RenderTarget &_window;
   Style _style;
   std::string _title;


### PR DESCRIPTION
Added support for mouse menu selections.
 - Support mouse position for current selected item. As mouse passes over text control, control is set to currently selected item.
 - Support mouse click for menu item action execution. Clicking within a text control boundary will run the action for that item.
 - Support mouse scroll wheel for current selected item. Same behavior as the up and down arrows, just implemented from the scroll wheel.

Implements enhancement request #2 
https://github.com/ParadoxZero/GameMenu-cpp/issues/2